### PR TITLE
upgrade to django 1.7

### DIFF
--- a/frigg/builds/migrations/0001_initial.py
+++ b/frigg/builds/migrations/0001_initial.py
@@ -1,67 +1,47 @@
 # -*- coding: utf-8 -*-
-from south.db import db
-from south.v2 import SchemaMigration
+from __future__ import unicode_literals
+
+from django.db import models, migrations
 
 
-class Migration(SchemaMigration):
+class Migration(migrations.Migration):
 
-    def forwards(self, orm):
-        # Adding model 'BuildResult'
-        db.create_table(u'builds_buildresult', (
-            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
-            ('result_log', self.gf('django.db.models.fields.TextField')()),
-            ('succeeded', self.gf('django.db.models.fields.BooleanField')(default=False)),
-            ('return_code', self.gf('django.db.models.fields.CharField')(max_length=100)),
-        ))
-        db.send_create_signal(u'builds', ['BuildResult'])
+    dependencies = [
+    ]
 
-        # Adding model 'Build'
-        db.create_table(u'builds_build', (
-            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
-            ('git_repository', self.gf('django.db.models.fields.CharField')(max_length=150)),
-            ('pull_request_id', self.gf('django.db.models.fields.IntegerField')(default=0,
-                                                                                max_length=150)),
-            ('branch', self.gf('django.db.models.fields.CharField')(default='master',
-                                                                    max_length=100)),
-            ('sha', self.gf('django.db.models.fields.CharField')(max_length=150)),
-            ('result', self.gf('django.db.models.fields.related.OneToOneField')(
-                to=orm['builds.BuildResult'],
-                unique=True,
-                null=True
-            )),
-        ))
-        db.send_create_signal(u'builds', ['Build'])
-
-    def backwards(self, orm):
-        # Deleting model 'BuildResult'
-        db.delete_table(u'builds_buildresult')
-
-        # Deleting model 'Build'
-        db.delete_table(u'builds_build')
-
-    models = {
-        u'builds.build': {
-            'Meta': {'object_name': 'Build'},
-            'branch': ('django.db.models.fields.CharField', [], {'default': "'master'",
-                                                                 'max_length': '100'}),
-            'git_repository': ('django.db.models.fields.CharField', [], {'max_length': '150'}),
-            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
-            'pull_request_id': ('django.db.models.fields.IntegerField', [], {'default': '0',
-                                                                             'max_length': '150'}),
-            'result': ('django.db.models.fields.related.OneToOneField', [], {
-                'to': u"orm['builds.BuildResult']",
-                'unique': 'True',
-                'null': 'True'
-            }),
-            'sha': ('django.db.models.fields.CharField', [], {'max_length': '150'})
-        },
-        u'builds.buildresult': {
-            'Meta': {'object_name': 'BuildResult'},
-            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
-            'result_log': ('django.db.models.fields.TextField', [], {}),
-            'return_code': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
-            'succeeded': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
-        }
-    }
-
-    complete_apps = ['builds']
+    operations = [
+        migrations.CreateModel(
+            name='Build',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True,
+                 primary_key=True)),
+                ('git_repository', models.CharField(max_length=150,
+                 verbose_name=b'git@github.com:owner/repo.git')),
+                ('pull_request_id', models.IntegerField(default=0, max_length=150)),
+                ('branch', models.CharField(default=b'master', max_length=100)),
+                ('sha', models.CharField(max_length=150)),
+            ],
+            options={
+            },
+            bases=(models.Model,),
+        ),
+        migrations.CreateModel(
+            name='BuildResult',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True,
+                 primary_key=True)),
+                ('result_log', models.TextField()),
+                ('succeeded', models.BooleanField(default=False)),
+                ('return_code', models.CharField(max_length=100)),
+            ],
+            options={
+            },
+            bases=(models.Model,),
+        ),
+        migrations.AddField(
+            model_name='build',
+            name='result',
+            field=models.OneToOneField(null=True, to='builds.BuildResult'),
+            preserve_default=True,
+        ),
+    ]

--- a/frigg/settings/base.py
+++ b/frigg/settings/base.py
@@ -36,7 +36,6 @@ INSTALLED_APPS = (
     'django.contrib.messages',
     'django.contrib.staticfiles',
 
-    'south',
     'frigg.builds'
 )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-django==1.6.7
+django==1.7
 south
 fabric
 requests


### PR DESCRIPTION
Removes south and south migrations in favor of django migrations.
To upgrade your deployed application run `python manage.py migrate
--fake builds` after you have installed django 1.7.
