### PR TITLE
Fix #108, return 404 in last build view

### DIFF
--- a/frigg/builds/fixtures/test_views.yaml
+++ b/frigg/builds/fixtures/test_views.yaml
@@ -49,3 +49,22 @@
     result_log: 'All ok'
     return_code: '0'
     succeeded: true
+
+- model: builds.project
+  pk: 2
+  fields:
+    average_time: 0
+    git_repository: 'git@github.com:frigg/chewie.git'
+    name: frigg
+    owner: chewie
+    members: []
+    private: false
+
+- model: builds.build
+  pk: 4
+  fields:
+    branch: master
+    build_number: 1
+    project: 2
+    pull_request_id: 0
+    sha: 6ebe61b9e030ff7f23d514f9f9ee7b1760b548c8

--- a/frigg/builds/views.py
+++ b/frigg/builds/views.py
@@ -38,8 +38,8 @@ def view_project(request, owner, name):
 
 
 def last_build(request, owner, name):
-    return redirect(Build.objects.permitted(request.user)
-                         .filter(project__owner=owner, project__name=name).first())
+    project = get_object_or_404(Project.objects.permitted(request.user), owner=owner, name=name)
+    return redirect(project.builds.first())
 
 
 def view_build(request, owner, name, build_number):


### PR DESCRIPTION
If a project does not exist or is not in permitted projects the view
should return 404
