### PR TITLE
Add support for reporting unfinished builds

### DIFF
--- a/frigg/api/fixtures/test_views.yaml
+++ b/frigg/api/fixtures/test_views.yaml
@@ -45,18 +45,18 @@
 - fields: {branch: master, build_number: 1, project: 4, pull_request_id: 0, sha: fjkds}
   model: builds.build
   pk: 5
-- fields: {build: 1, result_log: '...', return_code: '0', succeeded: true}
+- fields: {build: 1, result_log: '...', succeeded: true}
   model: builds.buildresult
   pk: 1
-- fields: {build: 2, result_log: '....', return_code: '0', succeeded: true}
+- fields: {build: 2, result_log: '....', succeeded: true}
   model: builds.buildresult
   pk: 2
-- fields: {build: 3, result_log: .., return_code: '0', succeeded: true}
+- fields: {build: 3, result_log: .., succeeded: true}
   model: builds.buildresult
   pk: 3
-- fields: {build: 4, result_log: .., return_code: '0', succeeded: true}
+- fields: {build: 4, result_log: .., succeeded: true}
   model: builds.buildresult
   pk: 4
-- fields: {build: 5, result_log: .., return_code: '0', succeeded: true}
+- fields: {build: 5, result_log: .., succeeded: true}
   model: builds.buildresult
   pk: 5

--- a/frigg/api/test_views.py
+++ b/frigg/api/test_views.py
@@ -29,7 +29,6 @@ class APITestMixin(object):
         self.assertEqual(obj['id'], result.id)
         self.assertEqual(obj['coverage'], result.coverage)
         self.assertEqual(obj['succeeded'], result.succeeded)
-        self.assertEqual(obj['return_code'], result.return_code)
         self.assertEqual(obj['tasks'], result.tasks)
 
     def assertNotAllowed(self, method, url):

--- a/frigg/builds/admin.py
+++ b/frigg/builds/admin.py
@@ -6,7 +6,7 @@ from .models import Build, BuildResult, Project
 
 class BuildResultInline(admin.StackedInline):
     model = BuildResult
-    readonly_fields = ('result_log', 'succeeded', 'return_code')
+    readonly_fields = ('result_log', 'succeeded')
     extra = 0
     max_num = 0
 
@@ -34,4 +34,4 @@ class BuildAdmin(admin.ModelAdmin):
 
 @admin.register(BuildResult)
 class BuildResultAdmin(admin.ModelAdmin):
-    list_display = ('__str__', 'succeeded', 'return_code', 'coverage')
+    list_display = ('__str__', 'succeeded', 'coverage')

--- a/frigg/builds/fixtures/test_permitted_objects.yaml
+++ b/frigg/builds/fixtures/test_permitted_objects.yaml
@@ -45,18 +45,18 @@
 - fields: {branch: master, build_number: 1, project: 4, pull_request_id: 0, sha: fjkds}
   model: builds.build
   pk: 5
-- fields: {build: 1, result_log: '...', return_code: '0', succeeded: true}
+- fields: {build: 1, result_log: '...', succeeded: true}
   model: builds.buildresult
   pk: 1
-- fields: {build: 2, result_log: '....', return_code: '0', succeeded: true}
+- fields: {build: 2, result_log: '....', succeeded: true}
   model: builds.buildresult
   pk: 2
-- fields: {build: 3, result_log: .., return_code: '0', succeeded: true}
+- fields: {build: 3, result_log: .., succeeded: true}
   model: builds.buildresult
   pk: 3
-- fields: {build: 4, result_log: .., return_code: '0', succeeded: true}
+- fields: {build: 4, result_log: .., succeeded: true}
   model: builds.buildresult
   pk: 4
-- fields: {build: 5, result_log: .., return_code: '0', succeeded: true}
+- fields: {build: 5, result_log: .., succeeded: true}
   model: builds.buildresult
   pk: 5

--- a/frigg/builds/fixtures/test_views.yaml
+++ b/frigg/builds/fixtures/test_views.yaml
@@ -38,7 +38,6 @@
   fields:
     build: 1
     result_log: 'All ok'
-    return_code: '0'
     succeeded: true
 
 - model: builds.buildresult
@@ -46,7 +45,6 @@
   fields:
     build: 3
     result_log: 'All ok'
-    return_code: '0'
     succeeded: true
 
 - model: builds.project

--- a/frigg/builds/migrations/0016_remove_buildresult_return_code.py
+++ b/frigg/builds/migrations/0016_remove_buildresult_return_code.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('builds', '0015_remove_project_average_time'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='buildresult',
+            name='return_code',
+        ),
+    ]

--- a/frigg/builds/migrations/0017_buildresult_still_running.py
+++ b/frigg/builds/migrations/0017_buildresult_still_running.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('builds', '0016_remove_buildresult_return_code'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='buildresult',
+            name='still_running',
+            field=models.BooleanField(default=False),
+            preserve_default=True,
+        ),
+    ]

--- a/frigg/builds/serializers.py
+++ b/frigg/builds/serializers.py
@@ -25,7 +25,6 @@ class BuildResultSerializer(serializers.ModelSerializer):
             'id',
             'coverage',
             'succeeded',
-            'return_code',
             'tasks',
         )
 

--- a/frigg/builds/templates/builds/build.html
+++ b/frigg/builds/templates/builds/build.html
@@ -79,13 +79,17 @@
       <div class="build-logs">
         {% for task, log, return_code in build.result.tasks %}
           <div>
-            <h3>
-              <i class="fa {% if return_code == '0' or return_code == '' %}fa-check green{% else %}fa-times red{% endif %}"></i>
-              {{ task }} <span class="meta">Return code: {{ return_code }}</span>
-            </h3>
-            <pre{% if return_code == '' or return_code == '0' %} style="display: none;"{% endif %}>
-              <code class="colorify">{{ log }}</code>
-            </pre>
+            {% if log == 'pending' %}
+              <h3><i class="fa fa-check fa-spinner fa-spin orange"></i> {{ task }}</h3>
+            {% else %}
+              <h3>
+                <i class="fa {% if return_code == '0' or return_code == '' %}fa-check green{% else %}fa-times red{% endif %}"></i>
+                {{ task }} <span class="meta">Return code: {{ return_code }}</span>
+              </h3>
+              <pre{% if return_code == '' or return_code == '0' %} style="display: none;"{% endif %}>
+                <code class="colorify">{{ log }}</code>
+              </pre>
+            {% endif %}
           </div>
         {% endfor %}
       </div>

--- a/frigg/files/sass/main.sass
+++ b/frigg/files/sass/main.sass
@@ -7,6 +7,7 @@ $transparent: rgba(0, 0, 0, 0)
 
 $green: #468847
 $red: #d9534f
+$orange: #f0ad4e
 
 body
   background: $background-color
@@ -124,7 +125,7 @@ pre
     border-left-color: $green
   &.orange
     background-color: #fcf8f2
-    border-left-color: #f0ad4e
+    border-left-color: $orange
 
 .build-logs
   h3
@@ -140,6 +141,10 @@ pre
       &.red
         color: $red
         background: transparent
+      &.orange
+        color: $orange
+        background: transparent
+
 
   .meta
     font-size: 0.6em

--- a/frigg/helpers/test_github.py
+++ b/frigg/helpers/test_github.py
@@ -118,7 +118,7 @@ class GithubHelpersTestCase(TestCase):
     def test__get_status_from_build(self):
         error = RuntimeError()
         build = Build.objects.create(build_number=1, branch='master', sha='sha')
-        BuildResult.objects.create(build=build, result_log='result', succeeded=True, return_code=0)
+        BuildResult.objects.create(build=build, result_log='result', succeeded=True)
 
         status = _get_status_from_build(build, True, None)[0]
         self.assertEqual(status, 'pending')
@@ -127,7 +127,6 @@ class GithubHelpersTestCase(TestCase):
         status = _get_status_from_build(build, False, error)[0]
         self.assertEqual(status, 'error')
         build.result.succeeded = False
-        build.result.return_code = 1
         build.result.save()
         status = _get_status_from_build(build, False, None)[0]
         self.assertEqual(status, 'failure')


### PR DESCRIPTION
In order to achieve this the log field will save json. There is need for
a two step deployment in order to convert existing logs to json without
breaking the build. This is the first pull-request of two that will
implement this feature.